### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,13 @@ Created using portions of cioportfolio/swardley-script as licensed under the MIT
 
 ## Running locally
 
-Dependancies for running locally.   NodeJS, Yarn and Jest.
+Dependancies for running locally. NodeJS and Yarn.
 
     npm install yarn -g
-    npm install jest -g
+
+Install dependencies
+
+    yarn install
 
 Commands:
 


### PR DESCRIPTION
Readme now contains command to install dependencies.
Removed command for global install of jest. (This shouldn't be required as it's installed with `yarn install`)