### PR TITLE
Feature/breadcrumb tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist
 .DS_Store
 yarn.lock
 package-lock.json
+coverage

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,6 @@
 module.exports = {
-    moduleNameMapper: {
-        '@/(.*)$': '<rootDir>/src/$1'
-    }
+	moduleNameMapper: {
+		'@/(.*)$': '<rootDir>/src/$1',
+	},
+	setupTestFrameworkScriptFile: './src/setupTests.js',
 };

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
 		"optimize-css-assets-webpack-plugin": "^5.0.1",
 		"prettier": "^1.19.1",
 		"pretty-quick": "^2.0.1",
+		"react-test-renderer": "^16.12.0",
 		"regenerator-runtime": "^0.13.1",
 		"sass-loader": "^7.1.0",
 		"style-loader": "^0.23.1",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
 		"@babel/cli": "^7.2.3",
 		"@babel/core": "^7.2.2",
 		"@babel/preset-env": "^7.2.3",
+		"@testing-library/jest-dom": "^4.2.4",
+		"@testing-library/react": "^9.4.0",
 		"babel-core": "7.0.0-bridge.0",
 		"babel-jest": "^23.6.0",
 		"babel-loader": "^8.0.5",

--- a/src/components/editor/Breadcrumb.js
+++ b/src/components/editor/Breadcrumb.js
@@ -7,8 +7,9 @@ const Breadcrumb = props => {
 				<li className="breadcrumb-item" data-testid="breadcrumb-list-item">
 					Your Map:{' '}
 					<a
-						href={props.currentUrl.indexOf('#') === -1 ? '' : props.currentUrl}
+						href={props.currentUrl.indexOf('#') === -1 ? '#' : props.currentUrl}
 						id="url"
+						data-testid="breadcrumb-list-item-your-map"
 					>
 						{props.currentUrl}
 					</a>

--- a/src/components/editor/Breadcrumb.js
+++ b/src/components/editor/Breadcrumb.js
@@ -4,7 +4,7 @@ const Breadcrumb = props => {
 	return (
 		<nav aria-label="breadcrumb">
 			<ol className="breadcrumb" data-testid="breadcrumb-list">
-				<li className="breadcrumb-item">
+				<li className="breadcrumb-item" data-testid="breadcrumb-list-item">
 					Your Map:{' '}
 					<a
 						href={props.currentUrl.indexOf('#') === -1 ? '' : props.currentUrl}

--- a/src/components/editor/Breadcrumb.js
+++ b/src/components/editor/Breadcrumb.js
@@ -3,7 +3,7 @@ import React from 'react';
 const Breadcrumb = props => {
 	return (
 		<nav aria-label="breadcrumb">
-			<ol className="breadcrumb">
+			<ol className="breadcrumb" data-testid="breadcrumb-list">
 				<li className="breadcrumb-item">
 					Your Map:{' '}
 					<a

--- a/src/components/editor/Breadcrumb.js
+++ b/src/components/editor/Breadcrumb.js
@@ -1,17 +1,17 @@
 import React from 'react';
 
-const Breadcrumb = props => {
+const Breadcrumb = ({ currentUrl }) => {
 	return (
 		<nav aria-label="breadcrumb">
 			<ol className="breadcrumb" data-testid="breadcrumb-list">
 				<li className="breadcrumb-item" data-testid="breadcrumb-list-item">
 					Your Map:{' '}
 					<a
-						href={props.currentUrl.indexOf('#') === -1 ? '#' : props.currentUrl}
+						href={currentUrl.indexOf('#') === -1 ? '#' : currentUrl}
 						id="url"
 						data-testid="breadcrumb-list-item-your-map"
 					>
-						{props.currentUrl}
+						{currentUrl.indexOf('#') > -1 ? currentUrl : '(unsaved)'}
 					</a>
 				</li>
 			</ol>

--- a/src/components/editor/Breadcrumb.js
+++ b/src/components/editor/Breadcrumb.js
@@ -11,7 +11,7 @@ const Breadcrumb = ({ currentUrl }) => {
 						id="url"
 						data-testid="breadcrumb-list-item-your-map"
 					>
-						{currentUrl.indexOf('#') > -1 ? currentUrl : '(unsaved)'}
+						{currentUrl.indexOf('#') === -1 ? '(unsaved)' : currentUrl}
 					</a>
 				</li>
 			</ol>

--- a/src/components/editor/Breadcrumb.js
+++ b/src/components/editor/Breadcrumb.js
@@ -1,16 +1,21 @@
 import React from 'react';
 
-const Breadcrumb = props => (
-	<nav aria-label="breadcrumb">
-		<ol className="breadcrumb">
-			<li className="breadcrumb-item">
-				Your Map: {' '}
-				<a href={props.currentUrl.indexOf('#') === -1 ? '' : props.currentUrl } id="url">
-					{props.currentUrl}
-				</a>
-			</li>
-		</ol>
-	</nav>
-);
+const Breadcrumb = props => {
+	return (
+		<nav aria-label="breadcrumb">
+			<ol className="breadcrumb">
+				<li className="breadcrumb-item">
+					Your Map:{' '}
+					<a
+						href={props.currentUrl.indexOf('#') === -1 ? '' : props.currentUrl}
+						id="url"
+					>
+						{props.currentUrl}
+					</a>
+				</li>
+			</ol>
+		</nav>
+	);
+};
 
 export default Breadcrumb;

--- a/src/components/editor/Breadcrumb.test.js
+++ b/src/components/editor/Breadcrumb.test.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import Breadcrumb from './Breadcrumb';
+import { create } from 'react-test-renderer';
+describe('Breadcrumb', () => {
+	describe('init', () => {
+		it('should render as a nav element', () => {
+			const component = create(<Breadcrumb currentUrl="(Unsaved)" />).toJSON();
+			expect(component.type).toBe('nav');
+		});
+	});
+});

--- a/src/components/editor/Breadcrumb.test.js
+++ b/src/components/editor/Breadcrumb.test.js
@@ -28,9 +28,9 @@ describe('Breadcrumb', () => {
 	});
 	describe('Unique Items', () => {
 		describe('Your Map', () => {
-			it('should have the text prefix "Your Map:"', () => {
+			it('should have the text prefix "Your Map:" before link', () => {
 				const component = render(<Breadcrumb currentUrl="(Unsaved)" />);
-				expect(component.getByText('Your Map:')).toBeDefined();
+				expect(component.getByText('Your Map:')).toContainHTML('Your Map: <a');
 			});
 			it('should render the value of provided currentUrl', () => {
 				const component = render(

--- a/src/components/editor/Breadcrumb.test.js
+++ b/src/components/editor/Breadcrumb.test.js
@@ -1,11 +1,23 @@
 import React from 'react';
 import Breadcrumb from './Breadcrumb';
 import { create } from 'react-test-renderer';
+import { render } from '@testing-library/react';
 describe('Breadcrumb', () => {
 	describe('init', () => {
 		it('should render as a nav element', () => {
 			const component = create(<Breadcrumb currentUrl="(Unsaved)" />).toJSON();
 			expect(component.type).toBe('nav');
+		});
+		it('should an aria-label attribute with value ""breadcrumb" - a11y', () => {
+			const component = create(<Breadcrumb currentUrl="(Unsaved)" />).toJSON();
+			expect(component.props['aria-label']).toBe('breadcrumb');
+		});
+		it('should render list with classname "breadcrumb" - a11y - styling hook', () => {
+			const component = render(<Breadcrumb currentUrl="(Unsaved)" />);
+
+			expect(component.getByTestId('breadcrumb-list')).toHaveClass(
+				'breadcrumb'
+			);
 		});
 	});
 });

--- a/src/components/editor/Breadcrumb.test.js
+++ b/src/components/editor/Breadcrumb.test.js
@@ -36,7 +36,12 @@ describe('Breadcrumb', () => {
 				const component = render(<Breadcrumb currentUrl="Some test String" />);
 				expect(component.getByText('Some test String')).toBeDefined();
 			});
-			it.skip('if provided currentUrl is "(unsaved)" anchor should link to an empty fragment', () => {});
+			it('if provided currentUrl is "(unsaved)" anchor should link to an empty fragment', () => {
+				const component = render(<Breadcrumb currentUrl="(Unsaved)" />);
+				expect(
+					component.getByTestId('breadcrumb-list-item-your-map')
+				).toHaveAttribute('href', '#');
+			});
 			it.skip('if valid link is provided the item should link to it.', () => {});
 			it.skip('should display "(unsaved)" in place of currentUrl value if junk data is provided', () => {});
 		});

--- a/src/components/editor/Breadcrumb.test.js
+++ b/src/components/editor/Breadcrumb.test.js
@@ -28,8 +28,14 @@ describe('Breadcrumb', () => {
 	});
 	describe('Unique Items', () => {
 		describe('Your Map', () => {
-			it.skip('should have the text prefix "Your Map"', () => {});
-			it.skip('should render the value of provided currentUrl', () => {});
+			it('should have the text prefix "Your Map:"', () => {
+				const component = render(<Breadcrumb currentUrl="(Unsaved)" />);
+				expect(component.getByText('Your Map:')).toBeDefined();
+			});
+			it('should render the value of provided currentUrl', () => {
+				const component = render(<Breadcrumb currentUrl="Some test String" />);
+				expect(component.getByText('Some test String')).toBeDefined();
+			});
 			it.skip('if provided currentUrl is "(unsaved)" anchor should link to an empty fragment', () => {});
 			it.skip('if valid link is provided the item should link to it.', () => {});
 			it.skip('should display "(unsaved)" in place of currentUrl value if junk data is provided', () => {});

--- a/src/components/editor/Breadcrumb.test.js
+++ b/src/components/editor/Breadcrumb.test.js
@@ -19,5 +19,11 @@ describe('Breadcrumb', () => {
 				'breadcrumb'
 			);
 		});
+		it('should render all list items with the className "breadcrumb-item"', () => {
+			const component = render(<Breadcrumb currentUrl="(Unsaved)" />);
+			component.getAllByTestId('breadcrumb-list-item').map(element => {
+				expect(element).toHaveClass('breadcrumb-item');
+			});
+		});
 	});
 });

--- a/src/components/editor/Breadcrumb.test.js
+++ b/src/components/editor/Breadcrumb.test.js
@@ -33,8 +33,14 @@ describe('Breadcrumb', () => {
 				expect(component.getByText('Your Map:')).toBeDefined();
 			});
 			it('should render the value of provided currentUrl', () => {
-				const component = render(<Breadcrumb currentUrl="Some test String" />);
-				expect(component.getByText('Some test String')).toBeDefined();
+				const component = render(
+					<Breadcrumb currentUrl="https://onlinewardleymaps.com/#SA88ATD3ly2Vn0v8CB" />
+				);
+				expect(
+					component.getByText(
+						'https://onlinewardleymaps.com/#SA88ATD3ly2Vn0v8CB'
+					)
+				).toBeDefined();
 			});
 			it('if provided currentUrl is "(unsaved)" anchor should link to an empty fragment', () => {
 				const component = render(<Breadcrumb currentUrl="(Unsaved)" />);
@@ -53,7 +59,14 @@ describe('Breadcrumb', () => {
 					'https://onlinewardleymaps.com/#qp4WjIQa8COMdvZt'
 				);
 			});
-			it.skip('should display "(unsaved)" in place of currentUrl value if junk data is provided', () => {});
+			it('should display "(unsaved)" in place of currentUrl value if junk data is provided', () => {
+				const component = render(
+					<Breadcrumb currentUrl="Some junk test String" />
+				);
+				expect(
+					component.getByTestId('breadcrumb-list-item-your-map')
+				).toContainHTML('(unsaved)');
+			});
 		});
 	});
 });

--- a/src/components/editor/Breadcrumb.test.js
+++ b/src/components/editor/Breadcrumb.test.js
@@ -26,4 +26,13 @@ describe('Breadcrumb', () => {
 			});
 		});
 	});
+	describe('Unique Items', () => {
+		describe('Your Map', () => {
+			it.skip('should have the text prefix "Your Map"', () => {});
+			it.skip('should render the value of provided currentUrl', () => {});
+			it.skip('if provided currentUrl is "(unsaved)" anchor should link to an empty fragment', () => {});
+			it.skip('if valid link is provided the item should link to it.', () => {});
+			it.skip('should display "(unsaved)" in place of currentUrl value if junk data is provided', () => {});
+		});
+	});
 });

--- a/src/components/editor/Breadcrumb.test.js
+++ b/src/components/editor/Breadcrumb.test.js
@@ -42,7 +42,17 @@ describe('Breadcrumb', () => {
 					component.getByTestId('breadcrumb-list-item-your-map')
 				).toHaveAttribute('href', '#');
 			});
-			it.skip('if valid link is provided the item should link to it.', () => {});
+			it('if valid link is provided the item should link to it.', () => {
+				const component = render(
+					<Breadcrumb currentUrl="https://onlinewardleymaps.com/#qp4WjIQa8COMdvZt" />
+				);
+				expect(
+					component.getByTestId('breadcrumb-list-item-your-map')
+				).toHaveAttribute(
+					'href',
+					'https://onlinewardleymaps.com/#qp4WjIQa8COMdvZt'
+				);
+			});
 			it.skip('should display "(unsaved)" in place of currentUrl value if junk data is provided', () => {});
 		});
 	});

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/extend-expect';


### PR DESCRIPTION
Relates to #23 

I've added jest-dom, react-test-renderer and react-testing-library. 
The breadcrumb tests have been added and have full coverage. I've deliberately stayed away from using snapshot tests in this PR. 
Planned follow-up work at the moment will be to whip through all the other components and add a static snapshot test to each of them this should throw some smells while we continue to refit them with the real deal.