### PR TITLE
Added husky and lint staged with config

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
 		"eslint-plugin-react": "^7.17.0",
 		"eslint-plugin-react-hooks": "^2.3.0",
 		"html-webpack-plugin": "^3.2.0",
+		"husky": "^3.1.0",
 		"jest": "^23.6.0",
+		"lint-staged": "^9.5.0",
 		"mini-css-extract-plugin": "^0.5.0",
 		"node-sass": "^4.11.0",
 		"optimize-css-assets-webpack-plugin": "^5.0.1",
@@ -53,11 +55,19 @@
 		"react-ace": "^8.0.0",
 		"react-dom": "^16.12.0"
 	},
+	"lint-staged": {
+		"*.{js,jsx}": [
+			"npm run prettify --staged",
+			"npm run lint src/ --fix",
+			"git add"
+		]
+	},
 	"scripts": {
 		"start": "webpack-dev-server --mode=development --env.isProduction=false",
 		"dist": "webpack --mode=production --env.isProduction=true",
 		"test": "jest --watchAll",
 		"lint": "eslint src/",
-		"prettify": "pretty-quick"
+		"prettify": "pretty-quick",
+		"precommit": "lint-staged"
 	}
 }


### PR DESCRIPTION
After the last lint fix run, I figured it might be nice to add some auto-checks into the workflow. 

In this commit I've added husky (https://github.com/typicode/husky) and lint-staged (https://github.com/okonet/lint-staged).

Once this goes in, run `yarn install`. Past this point, whenever a commit is attempted, the staged files will be autolinted (any automatic fixups will be performed automatically with a feed of any outstanding issues to be addressed) 

 In the event that a developer wants to bypass the linting (for example to share code with another developer to help them resolve an issue) they can run `git commit --no-verify` this will allow them to bypass the check. 