### PR TITLE
Add missing symbol files: Accelerate & deaccelerate, Ecosystem, Marke…

### DIFF
--- a/docs/_posts/2020-06-06-pioneers-settlers-townplanners.md
+++ b/docs/_posts/2020-06-06-pioneers-settlers-townplanners.md
@@ -1,41 +1,35 @@
 ---
 layout: post
-title: "Using Pioneers, Settlers and Town Planners"
-author: "OnlineWardleyMaps"
+title: 'Using Pioneers, Settlers and Town Planners'
+author: 'OnlineWardleyMaps'
 ---
 
 ## Usage:
 
 ```
-pioneers [<visibility>, <maturity>] width height
-settlers [<visibility>, <maturity>] width height
-townplanners [<visibility>, <maturity>] width height
+pioneers [<visibility>, <maturity>] <width> <height>
+settlers [<visibility>, <maturity>] <width> <height>
+townplanners [<visibility>, <maturity>] <width> <height>
 ```
 
-## Let's look at each part. 
+## Let's look at each part.
 
-`pioneers`, `settlers` and `townplanners` are keywords.  Each new line in your editor should begin with one of these keywords.   
+`pioneers`, `settlers` and `townplanners` are keywords. Each new line in your editor should begin with one of these keywords.
 
-`<visibility>` and `<maturity>` are the co-ordinates of where you want the block to appear on your map.  For example 0.9, 0.2 would translate roughly to _Visible_ and _Custom Built_.
+`<visibility>` and `<maturity>` are the co-ordinates of where you want the block to appear on your map. For example 0.9, 0.2 would translate roughly to _Visible_ and _Custom Built_.
 
+As we build it up it should now look like
 
+`pioneers [0.9, 0.2]`
 
-As we build it up it should now look like 
+Next up are the width and height properties. These are numbers. A good starter would be 150 80.
 
-``
-pioneers [0.9, 0.2]
-``
-
-Next up are the width and height properties.  These are numbers.  A good starter would be 150 80.
-
-``
-pioneers [0.9, 0.2] 150 80
-``
+`pioneers [0.9, 0.2] 150 80`
 
 An example of a Web Site component with pioneers would look like:
 
 ```
-component Web Site [0.82, 0.25] 
+component Web Site [0.82, 0.25]
 build Web Site
 pioneers [0.9, 0.2] 150 80
 ```

--- a/src/components/__snapshots__/Storyshots.test.js.snap
+++ b/src/components/__snapshots__/Storyshots.test.js.snap
@@ -393,7 +393,7 @@ exports[`Storyshots Usage  default 1`] = `
     href="#"
     onClick={[Function]}
   >
-    pioneers [&lt;visibility&gt;, &lt;maturity&gt;] width height
+    pioneers [&lt;visibility&gt;, &lt;maturity&gt;] &lt;width&gt; &lt;height&gt;
   </span>
   <br />
   <span
@@ -410,6 +410,45 @@ exports[`Storyshots Usage  default 1`] = `
     onClick={[Function]}
   >
     townplanners [0.31, 0.74] 200 150
+  </span>
+  <br />
+  <br />
+  ------------------------
+  <br />
+  <strong>
+    Build, buy, outsource components
+  </strong>
+  <br />
+   
+  Highlight a component with a build, buy, or outsource method of execution
+   
+  <br />
+  <strong>
+    Example:
+  </strong>
+  <br />
+  <span
+    className="add clickable"
+    href="#"
+    onClick={[Function]}
+  >
+    build &lt;component&gt;
+  </span>
+  <br />
+  <span
+    className="add clickable"
+    href="#"
+    onClick={[Function]}
+  >
+    buy &lt;component&gt;
+  </span>
+  <br />
+  <span
+    className="add clickable"
+    href="#"
+    onClick={[Function]}
+  >
+    outsource &lt;component&gt;
   </span>
   <br />
   <br />

--- a/src/components/map/MapCanvas.js
+++ b/src/components/map/MapCanvas.js
@@ -101,6 +101,7 @@ function MapCanvas(props) {
 										mapElements.getNonEvolvedElements(),
 										m.name
 									)}
+									mapStyleDefs={props.mapStyleDefs}
 									mapDimensions={props.mapDimensions}
 									method={m}
 								/>

--- a/src/components/map/MapComponent.js
+++ b/src/components/map/MapComponent.js
@@ -13,13 +13,14 @@ import SubMapSymbol from '../symbols/SubMapSymbol';
 
 function MapComponent(props) {
 	const positionCalc = new PositionCalculator();
-	const x = () =>
-		positionCalc.maturityToX(props.element.maturity, props.mapDimensions.width);
-	const y = () =>
-		positionCalc.visibilityToY(
-			props.element.visibility,
-			props.mapDimensions.height
-		);
+	const x = positionCalc.maturityToX(
+		props.element.maturity,
+		props.mapDimensions.width
+	);
+	const y = positionCalc.visibilityToY(
+		props.element.visibility,
+		props.mapDimensions.height
+	);
 
 	const onElementClick = () => props.setHighlightLine(props.element.line);
 
@@ -95,8 +96,8 @@ function MapComponent(props) {
 			<Movable
 				id={'element_' + props.element.id}
 				onMove={endDrag}
-				x={x()}
-				y={y()}
+				x={x}
+				y={y}
 				fixedY={props.element.evolved}
 				fixedX={false}
 			>
@@ -140,7 +141,7 @@ function MapComponent(props) {
 					mapDimensions={props.mapDimensions}
 				/>
 			) : null}
-			<g transform={'translate(' + x() + ',' + y() + ')'}>
+			<g transform={'translate(' + x + ',' + y + ')'}>
 				<ComponentText
 					id={'component_text_' + props.element.id}
 					mapStyleDefs={props.mapStyleDefs}

--- a/src/components/map/MethodElement.js
+++ b/src/components/map/MethodElement.js
@@ -1,50 +1,24 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import PositionCalculator from './PositionCalculator';
+import MethodSymbol from '../symbols/MethodSymbol';
 
-function MethodElement({ element, mapDimensions, method }) {
+function MethodElement({ element, mapDimensions, method, mapStyleDefs }) {
 	const positionCalc = new PositionCalculator();
-	const x = () =>
-		positionCalc.maturityToX(element.maturity, mapDimensions.width);
-	const y = () =>
-		positionCalc.visibilityToY(element.visibility, mapDimensions.height);
-
-	const defineStoke = function() {
-		switch (method.method) {
-			case 'outsource':
-				return '#444444';
-			case 'build':
-				return '#000000';
-			default:
-				return '#D6D6D6';
-		}
-	};
-
-	const defineFill = function() {
-		switch (method.method) {
-			case 'outsource':
-				return '#444444';
-			case 'build':
-				return '#D6D6D6';
-			default:
-				return '#AAA5A9';
-		}
-	};
+	const x = positionCalc.maturityToX(element.maturity, mapDimensions.width);
+	const y = positionCalc.visibilityToY(
+		element.visibility,
+		mapDimensions.height
+	);
 
 	return (
-		<g
+		<MethodSymbol
 			id={'method_' + element.id}
-			transform={'translate (' + x() + ',' + y() + ')'}
-		>
-			<circle
-				id={'element_circle_' + element.id}
-				cx="0"
-				cy="0"
-				r="20"
-				fill={defineFill()}
-				stroke={defineStoke()}
-			/>
-		</g>
+			x={x}
+			y={y}
+			method={method.method}
+			styles={mapStyleDefs.methods}
+		/>
 	);
 }
 

--- a/src/components/map/foundation/MapGraphics.js
+++ b/src/components/map/foundation/MapGraphics.js
@@ -1,5 +1,24 @@
-import React from 'react';
+import React, { memo } from 'react';
 import PropTypes from 'prop-types';
+
+const ecosystemStripesPattern = () => (
+	<pattern
+		id="diagonalHatch"
+		patternUnits="userSpaceOnUse"
+		width="4"
+		height="4"
+	>
+		<path
+			d="M 3,-1 l 2,2
+			 M 0,0 l 4,4
+			 M -1,3 l 2,2
+			 "
+			stroke="grey"
+			strokeWidth="1"
+			opacity=".5"
+		/>
+	</pattern>
+);
 
 const MapGraphics = props => (
 	<defs>
@@ -20,6 +39,18 @@ const MapGraphics = props => (
 			<stop offset="0.7" style={{ stopColor: 'white' }} />
 			<stop offset={1} style={{ stopColor: 'rgb(196, 196, 196)' }} />
 		</linearGradient>
+		<linearGradient
+			spreadMethod="pad"
+			id="accelGradient"
+			x1="0%"
+			y1="64%"
+			x2="76%"
+			y2="0%"
+		>
+			<stop offset="0%" style={{ stopColor: 'white', stopOpacity: 1 }} />
+			<stop offset="100%" style={{ stopColor: '#8c8995', stopOpacity: 1 }} />
+		</linearGradient>
+		{ecosystemStripesPattern()}
 		<marker
 			id="arrow"
 			markerWidth="12"
@@ -62,4 +93,4 @@ MapGraphics.propTypes = {
 	mapStyleDefs: PropTypes.object.isRequired,
 };
 
-export default MapGraphics;
+export default memo(MapGraphics);

--- a/src/components/symbols/AccelerateSymbol.js
+++ b/src/components/symbols/AccelerateSymbol.js
@@ -1,0 +1,26 @@
+import React, { memo } from 'react';
+import PropTypes from 'prop-types';
+
+const deaccelTransform = 'scale(-1,1) translate(-150)';
+
+const AccelerateSymbol = props => {
+	const { id, styles = {}, deaccel } = props;
+	return (
+		<polygon
+			id={id}
+			points="0,0 100,0 100,-25 150,25 100,75 100,50 0,50"
+			transform={deaccel ? deaccelTransform : ''}
+			fill="url(#accelGradient)"
+			stroke={styles.stroke}
+			strokeWidth="2"
+		/>
+	);
+};
+
+AccelerateSymbol.propTypes = {
+	id: PropTypes.string,
+	deaccel: PropTypes.bool,
+	styles: PropTypes.object.isRequired,
+};
+
+export default memo(AccelerateSymbol);

--- a/src/components/symbols/EcosystemSymbol.js
+++ b/src/components/symbols/EcosystemSymbol.js
@@ -1,0 +1,46 @@
+import React, { memo } from 'react';
+import PropTypes from 'prop-types';
+
+const EcosystemSymbol = props => {
+	const { id, cx, cy, onClick, styles = {} } = props;
+
+	return (
+		<g id={id} onClick={onClick}>
+			<circle
+				cx={cx}
+				cy={cy}
+				r="30"
+				fill="#d7d7d7"
+				strokeWidth="1"
+				stroke={styles.stroke}
+			/>
+			<circle
+				cx={cx}
+				cy={cy}
+				r="25"
+				fill="white"
+				strokeWidth="1"
+				stroke="#9e9b9e"
+			/>
+			<circle cx={cx} cy={cy} r="25" fill="url(#diagonalHatch)" />
+			<circle
+				cx={cx}
+				cy={cy}
+				r="10"
+				fill="white"
+				strokeWidth="1"
+				stroke="#6e6e6e"
+			/>
+		</g>
+	);
+};
+
+EcosystemSymbol.propTypes = {
+	onClick: PropTypes.func,
+	id: PropTypes.string,
+	cx: PropTypes.string,
+	cy: PropTypes.string,
+	styles: PropTypes.object.isRequired,
+};
+
+export default memo(EcosystemSymbol);

--- a/src/components/symbols/MarketSymbol.js
+++ b/src/components/symbols/MarketSymbol.js
@@ -1,0 +1,63 @@
+import React, { memo } from 'react';
+import PropTypes from 'prop-types';
+
+const SM_CIRC_RADIUS = 10;
+const polarCoord = (radius, angle) => [
+	Math.round(radius * Math.cos((angle * Math.PI) / 180)),
+	Math.round(radius * Math.sin((angle * Math.PI) / 180)),
+];
+
+const rotatePoints = () => {
+	const START_ANGLE = 30;
+	const ROTATE = 120;
+	const coords = [];
+	for (let i = 0; i < 3; i++) {
+		coords.push(polarCoord(SM_CIRC_RADIUS, START_ANGLE + ROTATE * i));
+	}
+	return coords;
+};
+const drawInsideCircles = (coords, styles) =>
+	coords.map((cxy, i) => (
+		<circle
+			key={i}
+			cx={cxy[0]}
+			cy={cxy[1]}
+			r="5"
+			fill={styles.fill}
+			strokeWidth="3"
+			stroke={styles.stroke}
+		/>
+	));
+
+const MarketSymbol = props => {
+	const { id, styles = {} } = props;
+	const coords = rotatePoints();
+	return (
+		<g id={id}>
+			<circle
+				r={SM_CIRC_RADIUS * 1.8}
+				fill={styles.fill}
+				strokeWidth="1"
+				stroke={styles.stroke}
+			/>
+			<path
+				strokeWidth="2"
+				stroke="black"
+				fill="none"
+				opacity=".8"
+				d={`M${coords[0]} L${coords[1]} L${coords[2]} Z`}
+			/>
+			{drawInsideCircles(coords, styles)}
+		</g>
+	);
+};
+
+MarketSymbol.propTypes = {
+	onClick: PropTypes.func,
+	id: PropTypes.string,
+	cx: PropTypes.string,
+	cy: PropTypes.string,
+	styles: PropTypes.object.isRequired,
+};
+
+export default memo(MarketSymbol);

--- a/src/components/symbols/MethodSymbol.js
+++ b/src/components/symbols/MethodSymbol.js
@@ -1,0 +1,23 @@
+import React, { memo } from 'react';
+import PropTypes from 'prop-types';
+
+const MethodSymbol = props => {
+	const { id, x, y, method, styles = {} } = props;
+	const style = styles[method] || {};
+	return (
+		<g id={id} transform={'translate (' + x + ',' + y + ')'}>
+			<circle cx="0" cy="0" r="20" fill={style.fill} stroke={style.stroke} />
+		</g>
+	);
+};
+
+MethodSymbol.propTypes = {
+	onClick: PropTypes.func,
+	id: PropTypes.string,
+	x: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+	y: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+	method: PropTypes.string,
+	styles: PropTypes.object.isRequired,
+};
+
+export default memo(MethodSymbol);

--- a/src/constants/editorPrefixes.js
+++ b/src/constants/editorPrefixes.js
@@ -9,8 +9,8 @@ const iterationBuilder = optArray => {
 const attitudes = ['pioneers', 'settlers', 'townplanners'].map(a => [
 	a,
 	'[<visibility>, <maturity>]',
-	'width',
-	'height',
+	'<width>',
+	'<height>',
 ]);
 
 const iterations = [

--- a/src/constants/mapstyles.js
+++ b/src/constants/mapstyles.js
@@ -39,6 +39,24 @@ export const Plain = {
 			strokeOpacity: 0.7,
 		},
 	},
+	methods: {
+		buy: {
+			stroke: '#D6D6D6',
+			fill: '#AAA5A9',
+		},
+		build: {
+			stroke: '#000000',
+			fill: '#D6D6D6',
+		},
+		outsource: {
+			stroke: '#444444',
+			fill: '#444444',
+		},
+	},
+	market: {
+		stroke: 'red',
+		fill: 'white',
+	},
 	component: {
 		fontSize: '13px',
 		fill: 'white',

--- a/src/constants/usages.js
+++ b/src/constants/usages.js
@@ -64,23 +64,31 @@ const usages = [
 			"Hot Water+'$0.10'>Kettle",
 		],
 	},
-	    {
+	{
 		title: 'Pioneers, Settlers, Townplanners area',
-		summary: 'Add areas indicating which type of working approach supports component development',
+		summary:
+			'Add areas indicating which type of working approach supports component development',
 		examples: [
-			'pioneers [<visibility>, <maturity>] width height',
+			'pioneers [<visibility>, <maturity>] <width> <height>',
 			'settlers [0.59, 0.43] 180 130',
-            		'townplanners [0.31, 0.74] 200 150',
+			'townplanners [0.31, 0.74] 200 150',
 		],
 	},
-    	{
+	{
+		title: 'Build, buy, outsource components',
+		summary:
+			'Highlight a component with a build, buy, or outsource method of execution',
+		examples: ['build <component>', 'buy <component>', 'outsource <component>'],
+	},
+	{
 		title: 'Link submap to a component',
-		summary: 'Add a reference link to a submap. A component becomes a link to an other Wardley Map',
+		summary:
+			'Add a reference link to a submap. A component becomes a link to an other Wardley Map',
 		examples: [
-            	'submap Component [<visibility>, <maturity>] url(urlName)',
-            	'url urlName [URL]',
-            	'submap Website [0.83, 0.50] url(submapUrl)',
-            	'url submapUrl [https://onlinewardleymaps.com/#clone:qu4VDDQryoZEnuw0ZZ]',
+			'submap Component [<visibility>, <maturity>] url(urlName)',
+			'url urlName [URL]',
+			'submap Website [0.83, 0.50] url(submapUrl)',
+			'url submapUrl [https://onlinewardleymaps.com/#clone:qu4VDDQryoZEnuw0ZZ]',
 		],
 	},
 	{


### PR DESCRIPTION
These are most of the missing symbols, only missing area of interest. I didn't implement the language elements or components, just the symbols themselves.

I'm not familiar with the use of these elements so I'm not sure how they should work within the language. From this reference map https://medium.com/wardleymaps/a-smorgasbord-of-the-slightly-useful-2498a1163dd6 It looks like both Market and Ecosystem should just be decorators for a component, since they seem like they can all be combined? Then the arrow marker needs to be updated for the market symbol, since the arrow should be hitting the edge. Currently covers it if the Market symbol is used in place of the component symbol. 

Accelerate can be flipped in the opposite direction with a boolean. Seems like the syntax for that element could just be "<accel or deaccel> [x,y] <optional text>"?
