### PR TITLE
fix: link components whose name contain keyword

### DIFF
--- a/src/__tests__/GivenConverter.js
+++ b/src/__tests__/GivenConverter.js
@@ -60,6 +60,18 @@ describe('Convert test suite', function() {
 		expect(result.links[0].flow).toBeFalsy();
 	});
 
+	test('should create links even if components name contains keyword', function() {
+		let actual =
+			'component Sales marketing [1, 0.4]\ncomponent Sales ecosystem [0,0.1]\nSales marketing->Sales ecosystem';
+
+		let obj = new Converter();
+		let result = obj.parse(actual);
+
+		expect(result.links[0].start).toEqual('Sales marketing');
+		expect(result.links[0].end).toEqual('Sales ecosystem');
+		expect(result.links[0].flow).toBeFalsy();
+	});
+
 	test('links should have flow attribute set', function() {
 		let actual =
 			'component Customer [1, 0.4]\ncomponent Customer2 [0,0.1]\nCustomer+>Customer2';

--- a/src/conversion/LinksExtractionStrategy.js
+++ b/src/conversion/LinksExtractionStrategy.js
@@ -110,7 +110,10 @@ export default class LinksExtractionStrategy {
 		let shouldProcess = true;
 		for (let j = 0; j < this.notLinks.length; j++) {
 			const shouldIgnore = this.notLinks[j];
-			if (element.trim().indexOf(shouldIgnore) !== -1) {
+			if (
+				element.trim().indexOf(shouldIgnore) == 0 ||
+				element.trim().indexOf('(' + shouldIgnore + ')') !== -1
+			) {
 				shouldProcess = false;
 			}
 		}


### PR DESCRIPTION
Attempt to fix https://github.com/damonsk/onlinewardleymaps/issues/107 and allow links between components in the edge case when their names contains special keywords (e.g. a component named _Sales **market**ing_).

Not sure if it conflicts with other parts of the parsing strategy, please let me know what you think.