### PR TITLE
Getting wmlandscape to run not in a browser

### DIFF
--- a/src/components/KeyPressContext.js
+++ b/src/components/KeyPressContext.js
@@ -44,7 +44,15 @@ export function useKeysPressed(allowedKeys) {
 	return pressedKeys;
 }
 
-const isDarwin = /Mac|iPod|iPhone|iPad/.test(window.navigator.platform);
+let onMac = null;
+
+if (typeof window === 'undefined') {
+	onMac = process.platform === 'darwin';
+} else {
+	onMac = /Mac|iPod|iPhone|iPad/.test(window.navigator.platform);
+}
+
+const isDarwin = onMac;
 const CTRL_OR_CMD = isDarwin ? 'Meta' : 'Control';
 
 // another custom hook composed from the useKeysPressed hook


### PR DESCRIPTION
I've been working to get the wmlandscape library to work on the
commandline. The `window` object doesnt exist in node. I've tried to make sure that this doesnt break anything,
and the variable declarations are a bit funky to make sure we get a `const` for isDarwin. Im a bit of a newcomer to node, so open to any and all feedback.