### PR TITLE
fixing some bugs with FlowText

### DIFF
--- a/src/components/map/ComponentLink.js
+++ b/src/components/map/ComponentLink.js
@@ -46,8 +46,8 @@ function ComponentLink(props) {
 					link={link}
 					metaText={props.metaText}
 					setMetaText={props.setMetaText}
-					x={x2}
-					y={y2}
+					x={x2.toString()}
+					y={y2.toString()}
 				/>
 			)}
 		</>

--- a/src/components/map/FlowText.js
+++ b/src/components/map/FlowText.js
@@ -51,6 +51,7 @@ const FlowText = props => {
 					textAnchor="start"
 					fill={mapStyleDefs.link.flowText}
 					text={link.flowValue}
+					styles={mapStyleDefs}
 				/>
 			</RelativeMovable>
 		</g>
@@ -64,7 +65,6 @@ FlowText.propTypes = {
 	link: PropTypes.object.isRequired,
 	startElement: PropTypes.object.isRequired,
 	endElement: PropTypes.object.isRequired,
-	mapText: PropTypes.string.isRequired,
 	setMetaText: PropTypes.func.isRequired,
 	mapStyleDefs: PropTypes.object.isRequired,
 };


### PR DESCRIPTION
When using FlowText in nodejs, the propTypes seem to be more enforced for some reason. 

Comments on each change next to the code.
