### PR TITLE
.github: Use node 22

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/master'
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 22
           registry-url: https://registry.npmjs.org/
         env:
           CI: true


### PR DESCRIPTION
Publishing fails with node 16, it needs at least node 18. Use node22 to match the Dockerfile.

Also fixes the checkout action to use a release branch (master is 5y old since the development switched to main)